### PR TITLE
Bug fixes

### DIFF
--- a/internal/pkg/httpsrv/stats.go
+++ b/internal/pkg/httpsrv/stats.go
@@ -17,9 +17,9 @@ func (w *sessionStats) inc() {
 
 func (s *Server) incStats(id string) {
 	// Find and increment.
-	for _, ws := range s.sessionStats {
+	for i, ws := range s.sessionStats {
 		if ws.id == id {
-			ws.inc()
+			s.sessionStats[i].inc()
 			return
 		}
 	}


### PR DESCRIPTION
**Bug#1:** 

- Problem: Seems like in stats.go file, the function `inc()` which counts the sent messages per watcher was not working right. `inc()` was called by a copy of a value from the slice `sessionStats` so the update (`w.sent++`) was not applied in the actual value, but in a copy.
- Fix: `inc()` function is now called by the actual object and not a copy. 