### PR TITLE
FeatureB: Extend API to return hex value in WS connection

### DIFF
--- a/internal/pkg/watcher/api.go
+++ b/internal/pkg/watcher/api.go
@@ -1,7 +1,8 @@
 package watcher
 
 type Counter struct {
-	Iteration int `json:"iteration"`
+	Iteration int    `json:"iteration"`
+	HexValue  string `json:"value"`
 }
 
 type CounterReset struct{}

--- a/internal/pkg/watcher/watcher.go
+++ b/internal/pkg/watcher/watcher.go
@@ -21,7 +21,7 @@ func New() *Watcher {
 	w.id = uuid.NewString()
 	w.inCh = make(chan string, 1)
 	w.outCh = make(chan *Counter, 1)
-	w.counter = &Counter{Iteration: 0}
+	w.counter = &Counter{Iteration: 0, HexValue: ""}
 	w.counterLock = &sync.RWMutex{}
 	w.quitChannel = make(chan struct{})
 	w.running = sync.WaitGroup{}
@@ -35,8 +35,9 @@ func (w *Watcher) Start() error {
 		defer wg.Done()
 		for {
 			select {
-			case <-w.inCh:
+			case hexVal := <-w.inCh:
 				w.counter.Iteration += 1
+				w.counter.HexValue = hexVal
 				select {
 				case w.outCh <- w.counter:
 				case <-w.quitChannel:
@@ -70,6 +71,7 @@ func (w *Watcher) ResetCounter() {
 	defer w.counterLock.Unlock()
 
 	w.counter.Iteration = 0
+	w.counter.HexValue = ""
 
 	select {
 	case w.outCh <- w.counter:


### PR DESCRIPTION
**Feature B:**

- Extended API to return also the hex value from feature A. This was done by adding one extra field `HexValue` in the struct `Counter` , and filling this field by reading the value of channel `inCh`.  `inCh` is filled with the hex value produced by `RandString()`.